### PR TITLE
Fix: 軽症・中等症・重症の欄を消す

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -1,5 +1,19 @@
 <template>
   <ul :class="$style.container">
+    <li :class="[$style.box, $style.tall, $style.tested]">
+      <div :class="[$style.pillar]">
+        <div :class="$style.content">
+          <span>
+            {{ $t('検査実施件数') }}
+            <br />({{ $t('累計') }})
+          </span>
+          <span>
+            <strong>{{ 検査実施件数 }}</strong>
+            <span :class="$style.unit">{{ $t('人') }}</span>
+          </span>
+        </div>
+      </div>
+    </li>
     <li :class="[$style.box, $style.tall, $style.parent, $style.confirmed]">
       <div :class="$style.pillar">
         <div :class="$style.content">
@@ -25,7 +39,7 @@
             </div>
           </div>
         </li>
-        <li :class="[$style.box, $style.parent, $style.hospitalized]">
+        <li :class="[$style.box, $style.recovered]">
           <div :class="$style.pillar">
             <div :class="$style.content">
               <span>{{ $t('入院中') }}</span>
@@ -35,32 +49,6 @@
               </span>
             </div>
           </div>
-          <ul :class="$style.group">
-            <li :class="[$style.box, $style.short, $style.minor]">
-              <div :class="$style.pillar">
-                <div :class="$style.content">
-                  <!-- eslint-disable vue/no-v-html-->
-                  <span v-html="$t('軽症・<br />中等症')" />
-                  <!-- eslint-enable vue/no-v-html-->
-                  <span>
-                    <strong>{{ 軽症中等症 }}</strong>
-                    <span :class="$style.unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
-              </div>
-            </li>
-            <li :class="[$style.box, $style.short, $style.severe]">
-              <div :class="$style.pillar">
-                <div :class="$style.content">
-                  <span>{{ $t('重症') }}</span>
-                  <span>
-                    <strong>{{ 重症 }}</strong>
-                    <span :class="$style.unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
-              </div>
-            </li>
-          </ul>
         </li>
         <li :class="[$style.box, $style.deceased]">
           <div :class="$style.pillar">
@@ -95,7 +83,7 @@ import Vue from 'vue'
 /* eslint-disable vue/prop-name-casing */
 export default Vue.extend({
   props: {
-    検査実施人数: {
+    検査実施件数: {
       type: Number,
       required: true
     },
@@ -104,14 +92,6 @@ export default Vue.extend({
       required: true
     },
     入院中: {
-      type: Number,
-      required: true
-    },
-    軽症中等症: {
-      type: Number,
-      required: true
-    },
-    重症: {
       type: Number,
       required: true
     },
@@ -207,6 +187,7 @@ $default-boxdiff: 35px;
     border-left: $default-bdw solid $green-1;
     position: relative;
     padding-top: $default-boxdiff - $default-bdw * 2;
+    margin-left: $default-bdw;
 
     &::after {
       content: '';
@@ -226,14 +207,23 @@ $default-boxdiff: 35px;
     }
   }
 
-  &.confirmed {
-    width: 100%;
+  &.tested {
+    // [7列] 1/7セル
+    width: calc((100% - #{$default-bdw} * 6) / 7);
+    color: $gray-1;
+    > .pillar {
+      border-color: $gray-1;
+    }
+  }
 
+  &.confirmed {
+    margin-left: $default-bdw;
+    // [7列] 6/7
+    width: calc((100% - #{$default-bdw} * 6) / 7 * 6 + #{$default-bdw} * 5);
     > .pillar {
       // [6列] 1/6
       width: calc((100% + #{$default-bdw} * 2) / 6 - #{$default-bdw} * 3);
     }
-
     > .group {
       // [6列] 5/6
       width: calc((100% + #{$default-bdw} * 2) / 6 * 5 + #{$default-bdw});
@@ -244,12 +234,10 @@ $default-boxdiff: 35px;
     margin-left: $default-bdw;
     // [5列] 3/5
     width: calc(100% / 5 * 3 - #{$default-bdw});
-
     > .pillar {
       // [3列] 1/3
       width: calc((100% + #{$default-bdw} * 2) / 3 - #{$default-bdw} * 3);
     }
-
     > .group {
       // [3列] 2/3
       width: calc((100% + #{$default-bdw} * 2) / 3 * 2 + #{$default-bdw});
@@ -267,7 +255,7 @@ $default-boxdiff: 35px;
   &.recovered {
     margin-left: $default-bdw;
     // [5列] 1/5
-    width: calc(100% / 5 - #{$default-bdw});
+    width: calc(100% / 4 - #{$default-bdw});
   }
 }
 
@@ -350,6 +338,10 @@ $default-boxdiff: 35px;
       }
     }
 
+    &.tested {
+      width: calc((100% - #{px2vw($bdw, $vw)} * 6) / 7);
+    }
+
     &.confirmed {
       > .pillar {
         width: calc(
@@ -390,7 +382,7 @@ $default-boxdiff: 35px;
     &.deceased,
     &.recovered {
       margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 - #{px2vw($bdw, $vw)});
+      width: calc(100% / 4 - #{px2vw($bdw, $vw)});
     }
   }
 }

--- a/data/main_summary.json
+++ b/data/main_summary.json
@@ -1,7 +1,7 @@
 {
     "date": "2020\/04\/17 20:00",
-    "attr": "検査実施人数",
-    "value": 833,
+    "attr": "検査実施件数",
+    "value": 967,
     "children": [
         {
             "attr": "陽性患者数",
@@ -9,17 +9,7 @@
             "children": [
                 {
                     "attr": "入院中",
-                    "value": 6,
-                    "children": [
-                        {
-                            "attr": "軽症・中等症",
-                            "value": "-"
-                        },
-                        {
-                            "attr": "重症",
-                            "value": "-"
-                        }
-                    ]
+                    "value": 6
                 },
                 {
                     "attr": "退院",

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -1,5 +1,5 @@
 type DataType = {
-  attr: '検査実施人数'
+  attr: '検査実施件数'
   value: number
   children: [
     {
@@ -9,16 +9,6 @@ type DataType = {
         {
           attr: '入院中'
           value: number
-          children: [
-            {
-              attr: '軽症・中等症'
-              value: number
-            },
-            {
-              attr: '重症'
-              value: number
-            }
-          ]
         },
         {
           attr: '退院'
@@ -38,11 +28,9 @@ type DataType = {
 }
 
 type ConfirmedCasesType = {
-  検査実施人数: number
+  検査実施件数: number
   陽性者数: number
   入院中: number
-  軽症中等症: number
-  重症: number
   死亡: number
   退院: number
   調査中: number
@@ -55,11 +43,9 @@ type ConfirmedCasesType = {
  */
 export default (data: DataType) => {
   const formattedData: ConfirmedCasesType = {
-    検査実施人数: data.value,
+    検査実施件数: data.value,
     陽性者数: data.children[0].value,
     入院中: data.children[0].children[0].value,
-    軽症中等症: data.children[0].children[0].children[0].value,
-    重症: data.children[0].children[0].children[1].value,
     死亡: data.children[0].children[2].value,
     退院: data.children[0].children[1].value,
     調査中: data.children[0].children[3].value


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #69

## 📝 関連する issue / Related Issues
- #69

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 県の報告には病状の記載がなされていないので、検査陽性者の状況から病状の欄を消去する

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/19589940/79564849-64332f00-80ea-11ea-9874-ae0707e7a3ee.png)

![image](https://user-images.githubusercontent.com/19589940/79601213-6e255400-8123-11ea-994c-16722dd7c50c.png)

